### PR TITLE
'type' => 'FieldLabelPosEnum' doesn't exist.

### DIFF
--- a/src/type/interface/class-form-field-interface.php
+++ b/src/type/interface/class-form-field-interface.php
@@ -88,7 +88,7 @@ class Form_Field_Interface {
 					],
 					'personallyIdentifiable' => [
 						'type'        => 'Boolean',
-						'description' => __( 'Indtifiable?', 'wp-graphql-ninja-forms' ),
+						'description' => __( 'Identifiable?', 'wp-graphql-ninja-forms' ),
 					],
 				],
 				'resolveType' => function ( Field_Model $model ) use ( &$type_registry ) {

--- a/src/type/interface/class-form-field-interface.php
+++ b/src/type/interface/class-form-field-interface.php
@@ -83,7 +83,7 @@ class Form_Field_Interface {
 						'description' => __( 'The field is required?', 'wp-graphql-ninja-forms' ),
 					],
 					'labelPos'               => [
-						'type'        => 'FieldLabelPosEnum',
+						FieldLabelPosEnum						'type'        => 'String',
 						'description' => __( 'Position of the label', 'wp-graphql-ninja-forms' ),
 					],
 					'personallyIdentifiable' => [

--- a/src/type/interface/class-form-field-interface.php
+++ b/src/type/interface/class-form-field-interface.php
@@ -83,7 +83,7 @@ class Form_Field_Interface {
 						'description' => __( 'The field is required?', 'wp-graphql-ninja-forms' ),
 					],
 					'labelPos'               => [
-						FieldLabelPosEnum						'type'        => 'String',
+						'type'        => 'String',
 						'description' => __( 'Position of the label', 'wp-graphql-ninja-forms' ),
 					],
 					'personallyIdentifiable' => [

--- a/src/type/object/class-field-type.php
+++ b/src/type/object/class-field-type.php
@@ -181,7 +181,7 @@ class Field_Type {
 				'description' => __( 'The field is required?', 'wp-graphql-ninja-forms' ),
 			],
 			'labelPos'               => [
-				'type'        => 'FieldLabelPosEnum',
+				'type'        => 'String',
 				'description' => __( 'Position of the label', 'wp-graphql-ninja-forms' ),
 			],
 			'personallyIdentifiable' => [

--- a/src/type/object/class-field-type.php
+++ b/src/type/object/class-field-type.php
@@ -186,7 +186,7 @@ class Field_Type {
 			],
 			'personallyIdentifiable' => [
 				'type'        => 'Boolean',
-				'description' => __( 'Indtifiable?', 'wp-graphql-ninja-forms' ),
+				'description' => __( 'Identifiable?', 'wp-graphql-ninja-forms' ),
 			],
 		];
 	}


### PR DESCRIPTION
'type' => 'FieldLabelPosEnum' doesn't exist. Because of this the 'labelPos' doesn't show up on the base FormField type. Changing it to a string fixes this. 

Also a small spelling fix.