### PR TITLE
eagerly load Field object type

### DIFF
--- a/src/class-type-registry.php
+++ b/src/class-type-registry.php
@@ -11,6 +11,7 @@ namespace WPGraphQL\NinjaForms;
 use WPGraphQL\Registry\TypeRegistry;
 
 use WPGraphQL\NinjaForms\Enum\Id_Type_Enums;
+use WPGraphQL\NinjaForms\Enum\Field_Label_Pos_Enums;
 use WPGraphQL\NinjaForms\Type\WPInterface\Form_Field_Interface;
 use WPGraphQL\NinjaForms\Type\WPObject\Form_Type;
 use WPGraphQL\NinjaForms\Type\WPObject\Field_Type;
@@ -32,6 +33,7 @@ class Type_Registry {
 	public function init( TypeRegistry $type_registry ) {
 		// enums.
 		Id_Type_Enums::register();
+		Field_Label_Pos_Enums::register();
 
 		// interfaces.
 		Form_Field_Interface::register( $type_registry );

--- a/src/type/enum/class-field-label-pos-enums.php
+++ b/src/type/enum/class-field-label-pos-enums.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Register the Enum used for the position of the field label
+ *
+ * @package WPGraphQL\NinjaForms\Type\Enum
+ * @since 0.1.0
+ */
+
+namespace WPGraphQL\NinjaForms\Enum;
+
+/**
+ * Class Field_label_Pos_Enums
+ */
+class Field_Label_Pos_Enums {
+	/**
+	 * Register the Enum used for the position of the field label
+	 */
+	public static function register() {
+		register_graphql_enum_type(
+			'FieldLabelPosEnum',
+			[
+				'description'     => __(
+					'The Enum used for the position of the field label.',
+					'wp-graphql-ninja-forms'
+				),
+				'values'      => [
+					'DEFAULT'     => [
+						'value'       => 'default',
+					],
+					'ABOVE'       => [
+						'value'       => 'above',
+					],
+					'BELOW'       => [
+						'value'       => 'below',
+					],
+					'LEFT'        => [
+						'value'       => 'left',
+					],
+					'RIGHT'       => [
+						'value'       => 'right',
+					],
+					'HIDDEN'       => [
+						'value'       => 'hidden',
+					],
+				],
+			]
+		);
+	}
+}

--- a/src/type/interface/class-form-field-interface.php
+++ b/src/type/interface/class-form-field-interface.php
@@ -83,7 +83,7 @@ class Form_Field_Interface {
 						'description' => __( 'The field is required?', 'wp-graphql-ninja-forms' ),
 					],
 					'labelPos'               => [
-						'type'        => 'String',
+						'type'        => 'FieldLabelPosEnum',
 						'description' => __( 'Position of the label', 'wp-graphql-ninja-forms' ),
 					],
 					'personallyIdentifiable' => [

--- a/src/type/object/class-field-type.php
+++ b/src/type/object/class-field-type.php
@@ -40,9 +40,10 @@ class Field_Type {
 			register_graphql_object_type(
 				$type_name,
 				[
-					'description' => $field->get_nicename(),
-					'interfaces'  => [ 'Node', 'DatabaseIdentifier', 'FormField' ],
-					'fields'      => $fields,
+					'description'		=> $field->get_nicename(),
+					'interfaces'		=> [ 'Node', 'DatabaseIdentifier', 'FormField' ],
+					'eagerlyLoadType'	=> true,
+					'fields'		=> $fields,
 				]
 			);
 		}


### PR DESCRIPTION
The union fields on type FormField (like TextBoxField, SubmitField etc) break without this line.